### PR TITLE
add bin directive for install of cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "description": "Converts SVG to TTF/EOT/WOFF/WOFF2/SVG format fonts.",
   "main": "src/index.js",
+  "bin" : { 
+    "svgtofont" : "./bin/cli.js" 
+  },
   "scripts": {
     "test": "node test/index.js"
   },


### PR DESCRIPTION
after installing `svgtofont` in a project, this change will allow it to be called from npm/npx within the project as a `svgtofont` bin. this solves issue #30.