### PR TITLE
feat: Generate Typescript enum & union types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import htmlMinifier from 'html-minifier';
 import { SVGIcons2SVGFontOptions } from 'svgicons2svgfont';
 import color from 'colors-cli';
 import { generateIconsSource, generateReactIcons } from './generate';
-import { createSVG, createTTF, createEOT, createWOFF, createWOFF2, createSvgSymbol, copyTemplate, CSSOptions, createHTML } from './utils';
+import { createSVG, createTTF, createEOT, createWOFF, createWOFF2, createSvgSymbol, copyTemplate, CSSOptions, createHTML, createTypescript, TypescriptOptions } from './utils';
 
 export type SvgToFontOptions = {
   /**
@@ -139,6 +139,12 @@ export type SvgToFontOptions = {
       url: string;
     }>;
   };
+
+  /**
+   * Create typescript file with declarations for icon classnames
+   * @default false
+   */
+  typescript?: boolean | TypescriptOptions
 }
 
 export default async (options: SvgToFontOptions = {}) => {
@@ -209,6 +215,9 @@ export default async (options: SvgToFontOptions = {}) => {
       });
     }
 
+    if (options.typescript) {
+      await createTypescript({ ...options, typescript: options.typescript })
+    }
 
     if (options.website) {
       const pageName = ['font-class', 'unicode', 'symbol'];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,8 +89,7 @@ export function snakeToUppercase(str: string) {
 
 export type TypescriptOptions = {
   extension?: 'ts' | 'tsx',
-  enumName?: string,
-  unionName?: string
+  enumName?: string
 }
 
 /**
@@ -99,7 +98,7 @@ export type TypescriptOptions = {
 export async function createTypescript(options: Omit<SvgToFontOptions, 'typescript'> & { typescript: TypescriptOptions | true }) {
   const tsOptions = options.typescript === true ? {} : options.typescript;
   const uppercaseFontName = snakeToUppercase(options.fontName);
-  const { extension = 'ts', enumName = uppercaseFontName, unionName = `${uppercaseFontName}Classname` } = tsOptions;
+  const { extension = 'ts', enumName = uppercaseFontName } = tsOptions;
   const DIST_PATH = path.join(options.dist, `${options.fontName}.${extension}`);
   const fileNames = filterSvgFiles(options.src).map(svgPath => path.basename(svgPath, path.extname(svgPath)));
 
@@ -108,7 +107,9 @@ export async function createTypescript(options: Omit<SvgToFontOptions, 'typescri
     `export enum ${enumName} {\n` +
       fileNames.map(name => `  ${snakeToUppercase(name)} = "${options.classNamePrefix}-${name}"`).join(',\n') +
     '\n}\n\n' +
-    `export type ${unionName} = keyof typeof ${enumName}`
+    `export type ${enumName}Classname = ${fileNames.map(name => `"${options.classNamePrefix}-${name}"`).join(' | ')}\n` +
+    `export type ${enumName}Icon = ${fileNames.map(name => `"${name}"`).join(' | ')}\n` +
+    `export const ${enumName}Prefix = "${options.classNamePrefix}-"`
   );
   console.log(`${color.green('SUCCESS')} Created ${DIST_PATH}`);
 }

--- a/test/example/index.js
+++ b/test/example/index.js
@@ -17,6 +17,7 @@ svgtofont({
     fontHeight: 1000,
     normalize: true
   },
+  typescript: true,
   // website = null, no demo html files
   website: {
     // Add a Github corner to your website


### PR DESCRIPTION
Added typescript file generation with some basic options.  Generates both enum and union type as I think both are useful in different ways.  Font name is converted from snake case to upper case for default enum name.  Typescript options are similar to the `css` option in that the options value can be a boolean.

Let me know what you think and of course feel free to change anything.

Generated typescript file:
```ts
export enum Svgtofont {
  Adobe = "svgtofont-adobe",
  Git = "svgtofont-git",
  Stylelint = "svgtofont-stylelint"
}

export type SvgtofontClassname = "svgtofont-adobe" | "svgtofont-git" | "svgtofont-stylelint"
export type SvgtofontIcon = "adobe" | "git" | "stylelint"
export const SvgtofontPrefix = "svgtofont-"
```