### PR TITLE
Support for react native functional components

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Read a set of SVG icons and ouput a TTF/EOT/WOFF/WOFF2/SVG font, Generator of fo
 
 - Supported font formats: `WOFF2`, `WOFF`, `EOT`, `TTF` and `SVG`.
 - Support SVG Symbol file.
-- Support [`React`](https://github.com/facebook/react) & [`TypeScript`](https://github.com/microsoft/TypeScript).
+- Support [`React`](https://github.com/facebook/react), [`ReactNative`](https://github.com/facebook/react-native) & [`TypeScript`](https://github.com/microsoft/TypeScript).
 - Support [`Less`](https://github.com/less/less.js)/[`Sass`](https://github.com/sass/sass)/[`Stylus`](https://github.com/stylus/stylus).
 - Allows to use custom templates (example `css`, `less` and etc).
 - Automatically generate a preview site.
@@ -261,6 +261,27 @@ import React from 'react';
 export const Git = props => (
   <svg viewBox="0 0 20 20" {...props}><path d="M2.6 10.59L8.38 4.8l1.69 -." fillRule="evenodd" /></svg>
 );
+```
+
+### outSVGReactNative
+
+> Type: `Boolean`  
+> Default value: `false`
+
+Output `./dist/reactNative/`, SVG generates `reactNative` components.
+
+```js
+import { Text } from 'react-native';
+
+const icons = { "Git": "__GitUnicodeChar__", "Adobe": "__AdobeUnicodeChar__" };
+
+export const RangeIconFont = props => {
+  const { name, ...rest } = props;
+  return (<Text style={{ fontFamily: 'svgtofont', fontSize: 16, color: '#000000', ...rest }}>
+    {icons[name]}
+  </Text>);
+};
+
 ```
 
 ### outSVGPath
@@ -746,6 +767,21 @@ import { ReactComponent as ComLogo } from './logo.svg';
 
 <ComLogo />
 ```
+
+### Using With ReactNative
+
+A unique component named after the font name is generated.
+
+Props are TextProps and are used as inline style.
+
+In addition, the name prop is mandatory and refers to svg names
+
+```jsx
+import { SvgToFont } from './SvgToFont';
+
+<SvgToFont fontSize={32} color="#fefefe" name={"Git"}  />
+```
+
 
 ## Contributors
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ svgtofont({
   fontName: (argv.fontName) || "svgfont", // font name
   css: true, // Create CSS files.
   outSVGReact: true,
+  outSVGReactNative: false,
   outSVGPath: true,
   svgicons2svgfont: {
     fontHeight: 1000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import color from 'colors-cli';
 import { autoConf, merge, AutoConfOption } from 'auto-config-loader';
 import { Config } from 'svgo';
 import { log } from './log';
-import { generateIconsSource, generateReactIcons } from './generate';
+import { generateIconsSource, generateReactIcons, generateReactNativeIcons } from './generate';
 import { createSVG, createTTF, createEOT, createWOFF, createWOFF2, createSvgSymbol, copyTemplate, CSSOptions, createHTML, createTypescript, TypescriptOptions } from './utils';
 
 export type SvgToFontOptions = {
@@ -49,6 +49,10 @@ export type SvgToFontOptions = {
    * Output `./dist/react/`, SVG generates `react` components.
    */
   outSVGReact?: boolean;
+  /**
+   * Output `./dist/reactNative/`, SVG generates `reactNative` component.
+   */
+  outSVGReactNative?: boolean;
   /**
    * Output `./dist/svgtofont.json`, The content is as follows:
    * @example
@@ -109,7 +113,7 @@ export type SvgToFontOptions = {
    */
   useNameAsUnicode?: boolean;
   /**
-   * consoles whenever {{ cssString }} template outputs unicode characters or css vars 
+   * consoles whenever {{ cssString }} template outputs unicode characters or css vars
    * @default false
    */
   useCSSVars?: boolean;
@@ -400,6 +404,10 @@ export default async (options: SvgToFontOptions = {}) => {
     if (options.outSVGReact) {
       const outPath = await generateReactIcons(options);
       log.log(`${color.green('SUCCESS')} Created React Components. `);
+    }
+    if (options.outSVGReactNative) {
+      generateReactNativeIcons(options, unicodeObject);
+      log.log(`${color.green('SUCCESS')} Created React Native Components. `);
     }
 
   } catch (error) {

--- a/test/example/index.js
+++ b/test/example/index.js
@@ -12,6 +12,7 @@ svgtofont({
   fontName: "svgtofont", // font name
   css: true, // Create CSS files.
   outSVGReact: true,
+  outSVGReactNative: true,
   outSVGPath: true,
   startNumber: 20000, // unicode start number
   svgicons2svgfont: {

--- a/test/templates/index.js
+++ b/test/templates/index.js
@@ -17,6 +17,7 @@ const options = {
   fontName: "svgtofont", // font name
   css: true, // Create CSS files.
   outSVGReact: true,
+  outSVGReactNative: true,
   outSVGPath: true,
   startNumber: 20000, // unicode start number
   svgicons2svgfont: {


### PR DESCRIPTION
Hello maintainers.

Why this PR : 
Ive many SVG's in a directory, in React Native, assets are loaded at buildTime.
So you must load all of them at the startup to be able to import them and add a babel transformer to make them as RN components.
The real issue with that is that it's not possible to do dynamic imports.
So a font is the main solution.

I did everything to not being dependent of an external React Native package.
Ive tested this implementation on my own project with success.

It was a little bit challenging because of those particularities: 
* unicode in this repo is not unicode but an Html Entity
* encodedChar is not a unicode
* Saving an html entity in a variable in RN requires to be a string and it will not be interpreted as an Html entity.
* We can't (from my knownledge) generates multiple components because we can't dynamic imports components from a variable string...


So here is a (among unknown others) implementation of your package for ReactNative.

I would love to see this merged after all your reviews.
Im sure that it'll help many ppl.

Feel free to give me your feedback.