### PR TITLE
move types out of deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,14 +67,6 @@
     ]
   },
   "dependencies": {
-    "@types/cheerio": "~0.22.31",
-    "@types/ejs": "~3.1.0",
-    "@types/fs-extra": "^11.0.1",
-    "@types/svg2ttf": "~5.0.1",
-    "@types/svgicons2svgfont": "~10.0.1",
-    "@types/ttf2eot": "~2.0.0",
-    "@types/ttf2woff": "~2.0.2",
-    "@types/ttf2woff2": "~2.0.0",
     "auto-config-loader": "^1.7.4",
     "cheerio": "~1.0.0-rc.12",
     "colors-cli": "~1.0.28",
@@ -93,7 +85,24 @@
     "yargs": "~17.7.1"
   },
   "devDependencies": {
-    "@types/csso": "^5.0.0",
+    "@types/cheerio": "~0.22.31",
+    "@types/ejs": "~3.1.0",
+    "@types/fs-extra": "^11.0.1",
+    "@types/ttf2eot": "~2.0.0",
+    "@types/ttf2woff": "~2.0.2",
+    "@types/ttf2woff2": "~2.0.0",
     "tsbb": "^4.1.5"
+  },
+  "peerDependencies": {
+    "@types/svg2ttf": "~5.0.1",
+    "@types/svgicons2svgfont": "~10.0.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/svg2ttf": {
+      "optional": true
+    },
+    "@types/svgicons2svgfont": {
+      "optional": true
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import image2uri from 'image2uri';
 import { SvgIcons2FontOptions } from 'svgicons2svgfont';
 import color from 'colors-cli';
 import { autoConf, merge, AutoConfOption } from 'auto-config-loader';
+import type { FontOptions } from 'svg2ttf';
 import { Config } from 'svgo';
 import { log } from './log';
 import { generateIconsSource, generateReactIcons, generateReactNativeIcons } from './generate';
@@ -125,7 +126,7 @@ export type SvgToFontOptions = {
   /**
    * This is the setting for [svg2ttf](https://github.com/fontello/svg2ttf/tree/c33a126920f46b030e8ce960cc7a0e38a6946bbc#svg2ttfsvgfontstring-options---buf)
    */
-  svg2ttf?: unknown;
+  svg2ttf?: FontOptions;
   website?: {
     /**
      * Add a Github corner to your website


### PR DESCRIPTION
Consumers of this package shouldn't need to download all of the types that aren't exposed as part of its api. Types that are exposed as part of `SvgToFontOptions` are moved to `peerDependencies` and types that are not have been moved to `devDependencies`.