### PR TITLE
fix: allow undefined website logo

### DIFF
--- a/src/website/index.ejs
+++ b/src/website/index.ejs
@@ -129,7 +129,7 @@
     </a>
   <%}%>
   <div class="header">
-    <%if(logo) {%>
+    <%if(typeof logo==='string' ) {%>
     <div class="logo">
       <a href="./"><%-logo%></a>
     </div>

--- a/test/example/index.js
+++ b/test/example/index.js
@@ -33,8 +33,8 @@ svgtofont({
     index: "unicode", // Enum{"font-class", "unicode", "symbol"}
     title: "svgtofont",
     favicon: path.resolve(rootPath, "favicon.png"),
-    // Must be a .svg format image.
-    logo: path.resolve(rootPath, "svg", "git.svg"),
+    // Must be a .svg format image. Missing here to ensure the example works without it.
+    // logo: path.resolve(rootPath, "svg", "git.svg"),
     version: pkg.version,
     meta: {
       description: "Converts SVG fonts to TTF/EOT/WOFF/WOFF2/SVG format.",


### PR DESCRIPTION
You can reproduce this error by commenting out the logo in `test/example/index.js` and running `npm run example`

<img width="807" alt="image" src="https://github.com/jaywcjlove/svgtofont/assets/3688847/a1c230a9-1a65-4cac-b448-4b42f9d77716">

I included the change in the test example to make it easy to reproduce but I can revert it if you would prefer to only include the fix.