### PR TITLE
fix: exclude svg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,10 @@ export default async (options: SvgToFontOptions = {}) => {
     if (excludeFormat.includes('ttf')) {
       fs.removeSync(ttfPath);
     }
+    const svgPath = path.join(options.dist, options.fontName + ".svg");
+    if (excludeFormat.includes('svg')) {
+      fs.removeSync(svgPath)
+    }
 
     if (options.css) {
       const styleTemplatePath = options.styleTemplates || path.resolve(__dirname, 'styles')


### PR DESCRIPTION
Removing the SVG file if included in `excludeFormat` option  #238 