### PR TITLE
feat: add support for 5+ digit unicode characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -285,12 +285,12 @@ export default async (options: SvgToFontOptions = {}) => {
       const _code = unicodeObject[name];
       let symbolName = options.classNamePrefix + options.symbolNameDelimiter + name
       let iconPart = symbolName + '">';
-      let encodedCodes: string | number = _code.charCodeAt(0);
+      let encodedCodes: string | number = _code.codePointAt(0);
 
       if (options.useNameAsUnicode) {
         symbolName = name;
         iconPart = prefix + '">' + name;
-        encodedCodes = _code.split('').map(x => x.charCodeAt(0)).join(';&amp;#');
+        encodedCodes = [..._code].map(x => x.codePointAt(0)).join(';&amp;#');
       } else {
         cssToVars.push(`$${symbolName}: "\\${encodedCodes.toString(16)}";\n`);
         if (options.useCSSVars) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export function createSVG(options: SvgToFontOptions = {}): Promise<Record<string
       let _name = path.basename(svgPath, ".svg");
       const glyph = fs.createReadStream(svgPath) as ReadStream & { metadata: { unicode: string[], name: string } };
 
-      const curUnicode = String.fromCharCode(startUnicode);
+      const curUnicode = String.fromCodePoint(startUnicode);
       const [_curUnicode, _startUnicode] = options.getIconUnicode
         ? (options.getIconUnicode(_name, curUnicode, startUnicode) || [curUnicode]) : [curUnicode];
 


### PR DESCRIPTION
Issue: #256 

Note that `codePointAt` can returned undefined if `_code` is an empty string. I was not sure how to handle the error so I left it as is (since it would be caught anyway).