### PR TITLE
fix: corrects ttf2eot buffer usage

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -232,7 +232,8 @@ export function createTTF(options: SvgToFontOptions = {}): Promise<Buffer> {
 export function createEOT(options: SvgToFontOptions = {}, ttf: Buffer) {
   return new Promise((resolve, reject) => {
     const DIST_PATH = path.join(options.dist, options.fontName + '.eot');
-    const eot = Buffer.from(ttf2eot(ttf).buffer);
+    const ttf2eotResult = ttf2eot(ttf);
+    const eot = Buffer.from(ttf2eotResult.buffer, ttf2eotResult.byteOffset, ttf2eotResult.byteLength);
 
     fs.writeFile(DIST_PATH, eot, (err: NodeJS.ErrnoException) => {
       if (err) {


### PR DESCRIPTION
Fixes incorrect EOT file generation caused by copying the full backing ArrayBuffer instead of the actual ttf2eot output.

ttf2eot returns a Uint8Array view into a larger pooled buffer (64KB on current Node versions).
The previous code used Buffer.from(ttf2eot(ttf).buffer), which copied the entire underlying buffer rather than the EOT payload. That produced bloated .eot files (~65KB instead of a few KB) and made output differ between runs.

I found this out while trying to produce deterministic outputs (meaning the hash of my scss should've matched between runs, but eot files hash applied by angular builds were always different).